### PR TITLE
retouching_sign_in

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,6 +1,6 @@
 class Address < ApplicationRecord
   belongs_to :user, optional: true
-  validates :postal_code, :prefecturs, :municipalities, :block_number, :building_name, :phone_number, presence: true
+  validates :postal_code, :prefecturs, :municipalities, :block_number, :phone_number, presence: true
 
   enum prefecturs:{
     北海道:1,青森県:2,岩手県:3,宮城県:4,秋田県:5,山形県:6,福島県:7,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,11 +4,15 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
         
-  validates :nickname, :first_name, :last_name, :first_name_kana, :last_name_kana, :birthday, presence: true
+  validates :nickname, presence: true
   validates :password, length: { minimum: 7 },
             format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i, message: "に半角英数字以外の文字が含まれてます。" }       
   validates :email, uniqueness:true, length:{ maximum: 255 }, 
-            format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i, message: "に使えない文字が入っています。" }      
+            format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i, message: "が正しい形式ではありません。" }   
+  validates :first_name, :last_name, presence: true,
+            format: { with: /\A[A-Z\p{Hiragana}\p{Han}]+\z/, message: "は英大文字か漢字、ひらがなのみです。" }
+  validates :first_name_kana, :last_name_kana, presence: true,
+            format: { with: /\A[A-Z\p{Katakana}]+\z/, message: "は英大文字かカタカナのみです。"}     
+  validates :birthday, presence: true
   has_one :address
 end
-

--- a/app/views/devise/registrations/new_address.html.haml
+++ b/app/views/devise/registrations/new_address.html.haml
@@ -18,7 +18,7 @@
           = f.label :prefecturs, "都道府県", class: "address__form__box__title"
           %span.address__form__box__title__req 必須
           %br/
-          = f.select :prefecturs, Address.prefecturs.keys, {}, {class: 'address__form__box__input'}
+          = f.select :prefecturs, Address.prefecturs.keys, {prompt: '----'}, {class: 'address__form__box__input'}
         .address__form__box
           = f.label :municipalities, "市区町村", class: "address__form__box__title"
           %span.address__form__box__title__req 必須

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -9,6 +9,7 @@ ja:
         current_password: 現在のパスワード
         current_sign_in_at: 現在のログイン時刻
         current_sign_in_ip: 現在のログインIPアドレス
+        nickname: ニックネーム
         email: Eメール
         encrypted_password: 暗号化パスワード
         failed_attempts: 失敗したログイン試行回数
@@ -28,10 +29,11 @@ ja:
         first_name: 性(漢字)
         last_name: 名(漢字)
         first_name_kana: 性(カナ)
-        last_name_kana: 名(漢字)
+        last_name_kana: 名(カナ)
         birthday: 生年月日
       address: 
         postal_code: 郵便番号
+        Prefecturs: 都道府県
         municipalities: 市区町村
         block_number: 番地
         building_name: 建物名

--- a/db/migrate/20200926155013_change_prefecturs_of_addresses.rb
+++ b/db/migrate/20200926155013_change_prefecturs_of_addresses.rb
@@ -1,0 +1,9 @@
+class ChangePrefectursOfAddresses < ActiveRecord::Migration[5.2]
+  def up
+    change_column :addresses, :prefecturs, :string, default: 0
+  end
+
+  def down
+    change_column :addresses, :prefecturs, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_20_095151) do
+ActiveRecord::Schema.define(version: 2020_09_26_155013) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "prefecturs", null: false
+    t.string "prefecturs", default: "----", null: false
     t.string "municipalities", null: false
     t.string "block_number", null: false
     t.string "building_name", null: false


### PR DESCRIPTION
### What
フリマアプリユーザー新規登録の名前（性、名　全角）と名前（性、名　カナ）にバリデーションを新たに追加、建物名のからの場合保存できないバリデーション削除、都道府県入力欄の初期値を空にした
### why
名前のところは意図しない入力内容を防ぐため、厳しいバリデーションする必要があったため、建物名はユーザー視点から見て必ず入力する内容でもなないため