### PR TITLE
ユーザー新規登録のバグ修正

### DIFF
--- a/app/views/cards/new.html.haml
+++ b/app/views/cards/new.html.haml
@@ -61,7 +61,7 @@
     %br
     #card_token
     %br
-    = submit_tag "追加する", id: "token_submit"
+    = submit_tag "追加する", id: "user-token_submit"
 
 %footer.footer
   = render 'items/footer'

--- a/app/views/devise/registrations/new_address.html.haml
+++ b/app/views/devise/registrations/new_address.html.haml
@@ -39,7 +39,7 @@
           %br/
           = f.text_field :phone_number, class: "address__form__box__input", placeholder: "例）012-345-6789" , type: "text", id: "phone_number"
         .address__form__submit
-          = f.submit "登録する", class: "address__form__submit__btn", id: "token_submit"
+          = f.submit "登録する", class: "address__form__submit__btn", id: "user-token_submit"
       = render "devise/shared/links" 
 
   %footer.footer

--- a/app/views/users/credit.html.haml
+++ b/app/views/users/credit.html.haml
@@ -68,6 +68,6 @@
             %br/
           = text_field_tag "cvc", "", class: "credit__form__box__input", placeholder: "カード背面3~4桁の番号", maxlength: "4", id: "cvc"
         .card_token
-          = submit_tag "追加する", id: "token_submit", class: "credit__form__submit-btn"
+          = submit_tag "追加する", id: "user-token_submit", class: "credit__form__submit-btn"
 %footer.footer
   = render 'items/footer'


### PR DESCRIPTION
# What
ユーザー新規登録において、登録ボタンを押してもと通信が行われないバグを修正した。
payjpで用いるtoke送信時のidとユーザー新規登録フォームのidが同じものであったため、ユーザー新規登録フォームのidを変更した。