### PR TITLE
Fix bug

### DIFF
--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -3,7 +3,7 @@ class CardsController < ApplicationController
   
   def new
     card = Card.where(user_id: current_user.id)
-    redirect_to card_path(current_user.id) if card.exists?
+    redirect_to card_path(card) if card.exists?
   end
 
 

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -19,7 +19,7 @@ class CardsController < ApplicationController
       ) 
       @card = Card.new(user_id: current_user.id, customer_id: customer.id, card_id: customer.default_card)
       if @card.save
-        redirect_to card_path(current_user.id)
+        redirect_to card_path(@card)
       else
         redirect_to pay_cards_path
       end
@@ -37,7 +37,6 @@ class CardsController < ApplicationController
   end
 
   def show #Cardのデータpayjpに送り情報を取り出す
-    @item = Item.find(params[:id])
     if @card.blank?
       redirect_to new_card_path 
     else

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -37,8 +37,6 @@
           = f.password_field :password_confirmation, prefix:'',class:"sessions__container__form__box-inputbox",placeholder:"7文字以上の英数字"
           %p ※ 英字と数字の両方を含めて設定してください
           %br/
-          -# %input.pass-checkbox{type: "checkbox"}
-          -# %label.pass-checkbox パスワードを表示する
 
         .sessions__container__form__box
           %h3 本人確認

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -24,22 +24,22 @@
           = f.label :password,"パスワード",class:"sessions__container__form__box-title"
           - if @minimum_password_length
             %em
-              (#{@minimum_password_length} 文字以上)
+              (7文字以上)
           %span.sessions__container__form__box-req 必須
           %br/
-          = f.password_field :password, prefix:'',class:"sessions__container__form__box-inputbox",placeholder:"○文字以上の英数字"
+          = f.password_field :password, prefix:'',class:"sessions__container__form__box-inputbox",placeholder:"7文字以上の英数字"
           %p ※ 英字と数字の両方を含めて設定してください
 
         .field.sessions__container__form__box
           = f.label :password_confirmation,"パスワード(確認用)",class:"sessions__container__form__box-title"
           %span.sessions__container__form__box-req 必須
           %br/
-          = f.password_field :password_confirmation, prefix:'',class:"sessions__container__form__box-inputbox",placeholder:"○文字以上の英数字"
+          = f.password_field :password_confirmation, prefix:'',class:"sessions__container__form__box-inputbox",placeholder:"7文字以上の英数字"
           %p ※ 英字と数字の両方を含めて設定してください
+          %br/
+          -# %input.pass-checkbox{type: "checkbox"}
+          -# %label.pass-checkbox パスワードを表示する
 
-          %input.pass-checkbox{type: "checkbox"}
-          %label.pass-checkbox パスワードを表示する
-      
         .sessions__container__form__box
           %h3 本人確認
           %p 安心・安全にご利用いただくために、お客さまの本人情報の登録にご協力ください。他のお客さまに公開されることはありません。

--- a/app/views/devise/registrations/new_address.html.haml
+++ b/app/views/devise/registrations/new_address.html.haml
@@ -2,8 +2,6 @@
   %header.header
     = render 'items/header' 
         
-
-
   .address
     %h2.address__top 個人情報入力
     .address__form

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -84,4 +84,5 @@
 %footer.footer
   = render "footer"
 
-= render "purchase_btn"
+- if user_signed_in?
+  = render "purchase_btn"

--- a/app/views/items/search.html.haml
+++ b/app/views/items/search.html.haml
@@ -18,4 +18,3 @@
 .footer
   = render 'footer'
 
-= render 'purchase_btn'

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -81,5 +81,3 @@
 
 %footer.footer
   = render 'footer'
-
-= render "purchase_btn"


### PR DESCRIPTION
# What
以下エラーの修正を行った。
・新規会員登録ページのパスワード入力部分に「○文字以上の英数字」と表示されており、「７文字以上の英数字」と表示を変更。
・購入者用アカウント以外のアカウントでマイページからカードの登録／変更ページに遷移しようとすると、エラー文が表示される。
・カードの登録ページで一度更新ボタンを押さないと、カード情報が登録できない。
・ログインしていない状態でも商品出品ページに遷移できてしまうが、実際に出品しようとするとエラー画面が表示される。