### PR TITLE
商品編集ページに遷移できないバグを解消

### DIFF
--- a/app/assets/javascripts/edit_item.js
+++ b/app/assets/javascripts/edit_item.js
@@ -1,6 +1,11 @@
 $(window).on("turbolinks:load", function() {
   var path = location.pathname ;
-  　if(document.URL.match("edit")) {
+  var directory01 = path.split("/");
+  var directory02 = directory01.slice(1,3);
+  var directory03 = directory01.slice(2, 3);
+  var directory04 = "/" + directory02.join('/');
+
+  　if(directory04 == `/items/${directory03}`) {
     var preview = $(
       `<div class="image-preview__wapper">
         <img class="preview">

--- a/app/assets/javascripts/edit_item.js
+++ b/app/assets/javascripts/edit_item.js
@@ -1,11 +1,5 @@
 $(window).on("turbolinks:load", function() {
-  var path = location.pathname ;
-  var directory01 = path.split("/");
-  var directory02 = directory01.slice(1,3);
-  var directory03 = directory01.slice(2, 3);
-  var directory04 = "/" + directory02.join('/');
-
-  　if(directory04 == `/items/${directory03}`) {
+  if(!document.URL.match("new")) {
     var preview = $(
       `<div class="image-preview__wapper">
         <img class="preview">

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -52,7 +52,7 @@ class ItemsController < ApplicationController
         if @item.update(item_params)
           redirect_to item_path(@item), notice: "商品を更新しました"
         else
-          render action: :edit
+          render 'edit'
         end
       else
         render 'edit'

--- a/app/views/items/_form_edit.html.haml
+++ b/app/views/items/_form_edit.html.haml
@@ -15,8 +15,8 @@
                 %br
                 またはクリックしてファイルをアップロード
                 .input-area
-                  = image.file_field :src, class: "hidden image_upload",name: "item[images_attributes][#{@item.images.count}][src]"
-            .image-preview__wapper{data:{index: @item.images.count - 1}}
+                  = image.file_field :src, class: "hidden image_upload",name: "item[images_attributes][#{image.index}][src]"
+            .image-preview__wapper{data:{index: image.index}}
               = image_tag image.object.src.to_s, class:"preview"
               .preview__btn
                 .preview__btn__delete

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -68,7 +68,7 @@
               = link_to '購入画面に進む', item_buyers_path(@item.id)
           - if user_signed_in? && current_user.id == @item.user.id
             %li.items__show__main__container__top__itemBox__btn__edit
-              = link_to '編集', edit_item_path
+              = link_to '編集', edit_item_path(@item)
             %li.items__show__main__container__top__itemBox__btn__delete
               = link_to '削除', item_path(@item), method: :delete
         

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -68,7 +68,7 @@
               = link_to '購入画面に進む', item_buyers_path(@item.id)
           - if user_signed_in? && current_user.id == @item.user.id
             %li.items__show__main__container__top__itemBox__btn__edit
-              = link_to '編集', '#'
+              = link_to '編集', edit_item_path
             %li.items__show__main__container__top__itemBox__btn__delete
               = link_to '削除', item_path(@item), method: :delete
         


### PR DESCRIPTION
# What
- 最終課題挙動確認で指摘された商品春愁ページに遷移できない問題を解消
商品詳細ページに商品編集ページヘのリンクを設定

- 編集ページの作動するedit_item.jsファイルの条件分岐を再設定
new_itemパス以外で作動する仕様に変更