### PR TITLE
fix_index_method

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,7 +4,7 @@ class ItemsController < ApplicationController
   before_action :category_parent_array, only: [:new, :create, :edit, :update]
 
   def index
-    @items = Item.all.limit(5).order("created_at DESC")
+    @items = Item.where(status: 1).limit(5).order("created_at DESC")
   end
 
   def new


### PR DESCRIPTION
# What
トップページ下部の商品一覧表示において、売り切れ済みの商品は表示されないよう変更を行った。

# Why
UX向上のため。